### PR TITLE
Removes the requirement for the clamp_on: substitution in favor of parsing the phase: substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ substitutions:
   ct_1:
     disable: "false"
     backfeed: "false"
-    phase: a
+    phase: ab
 ```
 Each clamp must be configured from the following options:
 
@@ -97,6 +97,14 @@ Each clamp must be configured from the following options:
 | `disable`  | `"true"`, `"false"`       | Marks the sensor as internal so all related measurement and calculations are ignored (must be in quotes due to ESPHome parsing inconsistencies)          |
 | `backfeed` | `"true"`, `"false"`       | Allows or clamps negative sensor values (also must be in quotes)                                 |
 | `phase`    | `a`, `b`, `c`, `ab`/`ba`, `ac`/`ca`, `bc`/`cb`, `abc`/`acb`/`bac`/`bca`/`cab`/`cba` | Sets the voltage phase or crossphase (for split-phase circuts) for the measurement, accepts permutations of the phase ordering, correct phase ordering here improves accuracy. **The first letter in the phase must be which phase the clamp is installed on.**|
+
+### The order of the letters in your "phase:" substitution matter!
+- The first letter in "phase:" should be the phase that the current clamp is installed on.
+- The second letter is only used for crossphase and 3-phase circuits, and should match the appropriate phase/leg.
+- The third letter is only used for 3-phase circuits and should match the appropriate phase.
+
+*This is the most complicated part of the configuration, it's important to get this right!*
+
 
 ## Some Math used for the sensors
 #### Real Power

--- a/README.md
+++ b/README.md
@@ -55,32 +55,32 @@ substitutions:
   energy_update_rate: 60s    # should be at least 2x the sensor_update_rate
 
   # Configuration for each CT clamp
-  ct_a:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_b:  {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_c:  {disable:  "true", backfeed: "false", phase: c,  clamp_on: phase_c}
-  ct_1:  {disable: "false", backfeed: "false", phase: ab, clamp_on: phase_a}
-  ct_2:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_3:  {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_4:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_5:  {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_6:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_7:  {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_8:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_9:  {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_10: {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_11: {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_12: {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_13: {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_14: {disable: "false", backfeed: "false", phase: ab, clamp_on: phase_a}
-  ct_15: {disable: "false", backfeed: "false", phase: ab, clamp_on: phase_a}
-  ct_16: {disable: "false", backfeed: "false", phase: ab, clamp_on: phase_a}
+  ct_a:  { disable: "false", backfeed: "false", phase: a  }
+  ct_b:  { disable: "false", backfeed: "false", phase: b  }
+  ct_c:  { disable:  "true", backfeed: "false", phase: c  }
+  ct_1:  { disable: "false", backfeed: "false", phase: ab }
+  ct_2:  { disable: "false", backfeed: "false", phase: a  }
+  ct_3:  { disable: "false", backfeed: "false", phase: b  }
+  ct_4:  { disable: "false", backfeed: "false", phase: a  }
+  ct_5:  { disable: "false", backfeed: "false", phase: b  }
+  ct_6:  { disable: "false", backfeed: "false", phase: a  }
+  ct_7:  { disable: "false", backfeed: "false", phase: b  }
+  ct_8:  { disable: "false", backfeed: "false", phase: a  }
+  ct_9:  { disable: "false", backfeed: "false", phase: b  }
+  ct_10: { disable: "false", backfeed: "false", phase: a  }
+  ct_11: { disable: "false", backfeed: "false", phase: b  }
+  ct_12: { disable: "false", backfeed: "false", phase: a  }
+  ct_13: { disable: "false", backfeed: "false", phase: b  }
+  ct_14: { disable: "false", backfeed: "false", phase: ab }
+  ct_15: { disable: "false", backfeed: "false", phase: ab }
+  ct_16: { disable: "false", backfeed: "false", phase: ab }
 ```
 #### Current Clamp Configuration
 
 Each Current Clamp has an entry in the substitutions section shown as single line yaml dictionaries.
 ```yaml
 substitutions:
-  ct_1:  {disable: "false", backfeed: "false", phase: ab, clamp_on: phase_a}
+  ct_1:  { disable: "false", backfeed: "false", phase: ab }
 ```
 Alternatively this can be represented as standard multiline yaml.
 ```yaml
@@ -89,7 +89,6 @@ substitutions:
     disable: "false"
     backfeed: "false"
     phase: a
-    clamp_on: phase_a
 ```
 Each clamp must be configured from the following options:
 
@@ -97,8 +96,7 @@ Each clamp must be configured from the following options:
 |------------|---------------------------|--------------------------------------------------------------------------------------------------|
 | `disable`  | `"true"`, `"false"`       | Marks the sensor as internal so all related measurement and calculations are ignored (must be in quotes due to ESPHome parsing inconsistencies)          |
 | `backfeed` | `"true"`, `"false"`       | Allows or clamps negative sensor values (also must be in quotes)                                 |
-| `phase`    | `a`, `b`, `c`, `ab`, `ac`, `bc`, `abc` | Sets the voltage phase or crossphase (for split-phase circuts) for the measurement, accepts permutations of the phase ordering, correct phase ordering here improves accuracy slightly and will be required when the clamp_on: substitution is retired|
-| `clamp_on` | `phase_a`, `phase_b`, `phase_c` | Specifies the physical phase where the clamp is actually installed (i.e. a split phase measurement across A and B with the clamp on phase_b (hopefully, this will be retired soon in favor of phase: letter ordering) |
+| `phase`    | `a`, `b`, `c`, `ab`/`ba`, `ac`/`ca`, `bc`/`cb`, `abc`/`acb`/`bac`/`bca`/`cab`/`cba` | Sets the voltage phase or crossphase (for split-phase circuts) for the measurement, accepts permutations of the phase ordering, correct phase ordering here improves accuracy. **The first letter in the phase must be which phase the clamp is installed on.**|
 
 ## Some Math used for the sensors
 #### Real Power

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -21,25 +21,25 @@ substitutions:
   energy_update_rate: 60s    # should be at least 2x the sensor_update_rate
 
   # Configuration for each CT clamp
-  ct_a:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_b:  {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_c:  {disable:  "true", backfeed: "false", phase: c,  clamp_on: phase_c}
-  ct_1:  {disable: "false", backfeed: "false", phase: ab, clamp_on: phase_a}
-  ct_2:  {disable: "false", backfeed: "false", phase: ab, clamp_on: phase_a}
-  ct_3:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_4:  {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_5:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_6:  {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_7:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_8:  {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_9:  {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_10: {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_11: {disable:  "true", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_12: {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
-  ct_13: {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_14: {disable: "false", backfeed: "false", phase: ab, clamp_on: phase_a}
-  ct_15: {disable: "false", backfeed: "false", phase: a,  clamp_on: phase_a}
-  ct_16: {disable: "false", backfeed: "false", phase: b,  clamp_on: phase_b}
+  ct_a:  { disable: "false", backfeed: "false", phase: a  }
+  ct_b:  { disable: "false", backfeed: "false", phase: b  }
+  ct_c:  { disable:  "true", backfeed: "false", phase: c  }
+  ct_1:  { disable: "false", backfeed: "false", phase: ab }
+  ct_2:  { disable: "false", backfeed: "false", phase: ab }
+  ct_3:  { disable: "false", backfeed: "false", phase: a  }
+  ct_4:  { disable: "false", backfeed: "false", phase: b  }
+  ct_5:  { disable: "false", backfeed: "false", phase: a  }
+  ct_6:  { disable: "false", backfeed: "false", phase: b  }
+  ct_7:  { disable: "false", backfeed: "false", phase: a  }
+  ct_8:  { disable: "false", backfeed: "false", phase: b  }
+  ct_9:  { disable: "false", backfeed: "false", phase: a  }
+  ct_10: { disable: "false", backfeed: "false", phase: b  }
+  ct_11: { disable:  "true", backfeed: "false", phase: a  }
+  ct_12: { disable: "false", backfeed: "false", phase: b  }
+  ct_13: { disable: "false", backfeed: "false", phase: a  }
+  ct_14: { disable: "false", backfeed: "false", phase: ab }
+  ct_15: { disable: "false", backfeed: "false", phase: a  }
+  ct_16: { disable: "false", backfeed: "false", phase: b  }
 
 
 

--- a/sensors/inputs.yaml
+++ b/sensors/inputs.yaml
@@ -60,133 +60,133 @@ sensor:
       ## CT Clamp Configuration ##
       #########################
       
-      - phase_id: ${ct_a.clamp_on}
+      - phase_id: ${clamp_on.ct_a}
         input: "A"
         power:
           id: phase_a_powermeas
         current:
           id: phase_a_apparentcurrent
 
-      - phase_id: ${ct_b.clamp_on}
+      - phase_id: ${clamp_on.ct_b}
         input: "B"
         power:
           id: phase_b_powermeas
         current:
           id: phase_b_apparentcurrent
 
-      - phase_id: ${ct_c.clamp_on}
+      - phase_id: ${clamp_on.ct_c}
         input: "C"
         power:
           id: phase_c_powermeas
         current:
           id: phase_c_apparentcurrent
 
-      - phase_id: ${ct_1.clamp_on}
+      - phase_id: ${clamp_on.ct_1}
         input: "1"
         power:
           id: cir1_powermeas
         current:
           id: cir1_apparentcurrent
 
-      - phase_id: ${ct_2.clamp_on}
+      - phase_id: ${clamp_on.ct_2}
         input: "2"
         power:
           id: cir2_powermeas
         current:
           id: cir2_apparentcurrent
 
-      - phase_id: ${ct_3.clamp_on}
+      - phase_id: ${clamp_on.ct_3}
         input: "3"
         power:
           id: cir3_powermeas
         current:
           id: cir3_apparentcurrent
 
-      - phase_id: ${ct_4.clamp_on}
+      - phase_id: ${clamp_on.ct_4}
         input: "4"
         power:
           id: cir4_powermeas
         current:
           id: cir4_apparentcurrent
 
-      - phase_id: ${ct_5.clamp_on}
+      - phase_id: ${clamp_on.ct_5}
         input: "5"
         power:
           id: cir5_powermeas
         current:
           id: cir5_apparentcurrent
 
-      - phase_id: ${ct_6.clamp_on}
+      - phase_id: ${clamp_on.ct_6}
         input: "6"
         power:
           id: cir6_powermeas
         current:
           id: cir6_apparentcurrent
 
-      - phase_id: ${ct_7.clamp_on}
+      - phase_id: ${clamp_on.ct_7}
         input: "7"
         power:
           id: cir7_powermeas
         current:
           id: cir7_apparentcurrent
 
-      - phase_id: ${ct_8.clamp_on}
+      - phase_id: ${clamp_on.ct_8}
         input: "8"
         power:
           id: cir8_powermeas
         current:
           id: cir8_apparentcurrent
 
-      - phase_id: ${ct_9.clamp_on}
+      - phase_id: ${clamp_on.ct_9}
         input: "9"
         power:
           id: cir9_powermeas
         current:
           id: cir9_apparentcurrent
 
-      - phase_id: ${ct_10.clamp_on}
+      - phase_id: ${clamp_on.ct_10}
         input: "10"
         power:
           id: cir10_powermeas
         current:
           id: cir10_apparentcurrent
 
-      - phase_id: ${ct_11.clamp_on}
+      - phase_id: ${clamp_on.ct_11}
         input: "11"
         power:
           id: cir11_powermeas
         current:
           id: cir11_apparentcurrent
 
-      - phase_id: ${ct_12.clamp_on}
+      - phase_id: ${clamp_on.ct_12}
         input: "12"
         power:
           id: cir12_powermeas
         current:
           id: cir12_apparentcurrent
 
-      - phase_id: ${ct_13.clamp_on}
+      - phase_id: ${clamp_on.ct_13}
         input: "13"
         power:
           id: cir13_powermeas
         current:
           id: cir13_apparentcurrent
 
-      - phase_id: ${ct_14.clamp_on}
+      - phase_id: ${clamp_on.ct_14}
         input: "14"
         power:
           id: cir14_powermeas
         current:
           id: cir14_apparentcurrent
 
-      - phase_id: ${ct_15.clamp_on}
+      - phase_id: ${clamp_on.ct_15}
         input: "15"
         power:
           id: cir15_powermeas
         current:
           id: cir15_apparentcurrent
 
-      - phase_id: ${ct_16.clamp_on}
+      - phase_id: ${clamp_on.ct_16}
         input: "16"
         power:
           id: cir16_powermeas

--- a/vue_base.yaml
+++ b/vue_base.yaml
@@ -23,6 +23,25 @@ phase_config: # Do Not edit here. Edit the substitutions.
   phase_a_c_voltage: phase_a_c_voltage
   phase_a_b_c_voltage: phase_a_b_c_voltage
 
+substitutions:
+  clamp_on:
+    cir1:   'phase_${ct_1.phase[0:1]}
+    cir2:   'phase_${ct_2.phase[0:1]}
+    cir3:   'phase_${ct_3.phase[0:1]}
+    cir4:   'phase_${ct_4.phase[0:1]}
+    cir5:   'phase_${ct_5.phase[0:1]}
+    cir6:   'phase_${ct_6.phase[0:1]}
+    cir7:   'phase_${ct_7.phase[0:1]}
+    cir8:   'phase_${ct_8.phase[0:1]}
+    cir9:   'phase_${ct_9.phase[0:1]}
+    cir10: 'phase_${ct_10.phase[0:1]}
+    cir11: 'phase_${ct_11.phase[0:1]}
+    cir12: 'phase_${ct_12.phase[0:1]}
+    cir13: 'phase_${ct_13.phase[0:1]}
+    cir14: 'phase_${ct_14.phase[0:1]}
+    cir15: 'phase_${ct_15.phase[0:1]}
+    cir16: 'phase_${ct_16.phase[0:1]}
+
 packages:
   - !include sensors/inputs.yaml
   - !include sensors/grid_sensors.yaml

--- a/vue_base.yaml
+++ b/vue_base.yaml
@@ -9,7 +9,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/Legot/emporia-vue-local-extended
-      ref: main  # Should always be main unless testing
+      ref: dev  # Should always be main unless testing
     components: [phase_config]
     refresh: 0s
 

--- a/vue_base.yaml
+++ b/vue_base.yaml
@@ -25,25 +25,25 @@ phase_config: # Do Not edit here. Edit the substitutions.
 
 substitutions:
   clamp_on:
-    phasea: 'phase_${ct_a.phase[0:1]}
-    phaseb: 'phase_${ct_b.phase[0:1]}
-    phasec: 'phase_${ct_c.phase[0:1]}
-    cir1:   'phase_${ct_1.phase[0:1]}
-    cir2:   'phase_${ct_2.phase[0:1]}
-    cir3:   'phase_${ct_3.phase[0:1]}
-    cir4:   'phase_${ct_4.phase[0:1]}
-    cir5:   'phase_${ct_5.phase[0:1]}
-    cir6:   'phase_${ct_6.phase[0:1]}
-    cir7:   'phase_${ct_7.phase[0:1]}
-    cir8:   'phase_${ct_8.phase[0:1]}
-    cir9:   'phase_${ct_9.phase[0:1]}
-    cir10: 'phase_${ct_10.phase[0:1]}
-    cir11: 'phase_${ct_11.phase[0:1]}
-    cir12: 'phase_${ct_12.phase[0:1]}
-    cir13: 'phase_${ct_13.phase[0:1]}
-    cir14: 'phase_${ct_14.phase[0:1]}
-    cir15: 'phase_${ct_15.phase[0:1]}
-    cir16: 'phase_${ct_16.phase[0:1]}
+    ct_a: 'phase_${ct_a.phase[0:1]}
+    ct_b: 'phase_${ct_b.phase[0:1]}
+    ct_c: 'phase_${ct_c.phase[0:1]}
+    ct_1:   'phase_${ct_1.phase[0:1]}
+    ct_2:   'phase_${ct_2.phase[0:1]}
+    ct_3:   'phase_${ct_3.phase[0:1]}
+    ct_4:   'phase_${ct_4.phase[0:1]}
+    ct_5:   'phase_${ct_5.phase[0:1]}
+    ct_6:   'phase_${ct_6.phase[0:1]}
+    ct_7:   'phase_${ct_7.phase[0:1]}
+    ct_8:   'phase_${ct_8.phase[0:1]}
+    ct_9:   'phase_${ct_9.phase[0:1]}
+    ct_10: 'phase_${ct_10.phase[0:1]}
+    ct_11: 'phase_${ct_11.phase[0:1]}
+    ct_12: 'phase_${ct_12.phase[0:1]}
+    ct_13: 'phase_${ct_13.phase[0:1]}
+    ct_14: 'phase_${ct_14.phase[0:1]}
+    ct_15: 'phase_${ct_15.phase[0:1]}
+    ct_16: 'phase_${ct_16.phase[0:1]}
 
 packages:
   - !include sensors/inputs.yaml

--- a/vue_base.yaml
+++ b/vue_base.yaml
@@ -25,25 +25,25 @@ phase_config: # Do Not edit here. Edit the substitutions.
 
 substitutions:
   clamp_on:
-    ct_a: 'phase_${ct_a.phase[0:1]}
-    ct_b: 'phase_${ct_b.phase[0:1]}
-    ct_c: 'phase_${ct_c.phase[0:1]}
-    ct_1:   'phase_${ct_1.phase[0:1]}
-    ct_2:   'phase_${ct_2.phase[0:1]}
-    ct_3:   'phase_${ct_3.phase[0:1]}
-    ct_4:   'phase_${ct_4.phase[0:1]}
-    ct_5:   'phase_${ct_5.phase[0:1]}
-    ct_6:   'phase_${ct_6.phase[0:1]}
-    ct_7:   'phase_${ct_7.phase[0:1]}
-    ct_8:   'phase_${ct_8.phase[0:1]}
-    ct_9:   'phase_${ct_9.phase[0:1]}
-    ct_10: 'phase_${ct_10.phase[0:1]}
-    ct_11: 'phase_${ct_11.phase[0:1]}
-    ct_12: 'phase_${ct_12.phase[0:1]}
-    ct_13: 'phase_${ct_13.phase[0:1]}
-    ct_14: 'phase_${ct_14.phase[0:1]}
-    ct_15: 'phase_${ct_15.phase[0:1]}
-    ct_16: 'phase_${ct_16.phase[0:1]}
+    ct_a:   'phase_${ct_a.phase[0:1]}'
+    ct_b:   'phase_${ct_b.phase[0:1]}'
+    ct_c:   'phase_${ct_c.phase[0:1]}'
+    ct_1:   'phase_${ct_1.phase[0:1]}'
+    ct_2:   'phase_${ct_2.phase[0:1]}'
+    ct_3:   'phase_${ct_3.phase[0:1]}'
+    ct_4:   'phase_${ct_4.phase[0:1]}'
+    ct_5:   'phase_${ct_5.phase[0:1]}'
+    ct_6:   'phase_${ct_6.phase[0:1]}'
+    ct_7:   'phase_${ct_7.phase[0:1]}'
+    ct_8:   'phase_${ct_8.phase[0:1]}'
+    ct_9:   'phase_${ct_9.phase[0:1]}'
+    ct_10: 'phase_${ct_10.phase[0:1]}'
+    ct_11: 'phase_${ct_11.phase[0:1]}'
+    ct_12: 'phase_${ct_12.phase[0:1]}'
+    ct_13: 'phase_${ct_13.phase[0:1]}'
+    ct_14: 'phase_${ct_14.phase[0:1]}'
+    ct_15: 'phase_${ct_15.phase[0:1]}'
+    ct_16: 'phase_${ct_16.phase[0:1]}'
 
 packages:
   - !include sensors/inputs.yaml

--- a/vue_base.yaml
+++ b/vue_base.yaml
@@ -25,6 +25,9 @@ phase_config: # Do Not edit here. Edit the substitutions.
 
 substitutions:
   clamp_on:
+    phasea: 'phase_${ct_a.phase[0:1]}
+    phaseb: 'phase_${ct_b.phase[0:1]}
+    phasec: 'phase_${ct_c.phase[0:1]}
     cir1:   'phase_${ct_1.phase[0:1]}
     cir2:   'phase_${ct_2.phase[0:1]}
     cir3:   'phase_${ct_3.phase[0:1]}

--- a/vue_base.yaml
+++ b/vue_base.yaml
@@ -9,7 +9,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/Legot/emporia-vue-local-extended
-      ref: dev  # Should always be main unless testing
+      ref: main  # Should always be main unless testing
     components: [phase_config]
     refresh: 0s
 


### PR DESCRIPTION
clamp_on: is no longer required for any phase
phase: abc letter ordering now matters, see README.md